### PR TITLE
Allow to use magic with zsh plugin manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,9 @@ define bash functions on a per-directory basis
 
 `make DESTDIR=stage install` for a staged install.
 
-Add the following line to your .bashrc:
+Add the following line to your .bashrc or .zshrc:
 
-    PROMPT_COMMAND="$PROMPT_COMMAND; source /usr/lib/magic/magic"
-
-Or if you use zsh, add this to your .zshrc:
-
-    precmd() { eval "$PROMPT_COMMAND" }
-    PROMPT_COMMAND="source /usr/lib/magic/magic"
+    source /usr/lib/magic/magic
 
 If you used a different `PREFIX`, adjust the path accordingly.
 

--- a/magic
+++ b/magic
@@ -1,37 +1,49 @@
 # -*- shell-script -*-
 
-function magic_from() {
-    local dir="$1"
-    [[ -z "$dir" ]] && return
+function magic_load() {
 
-    while [[ "$dir" != "/" ]]; do
-        [[ -r "$dir/.spells" ]] && echo "$dir"
-        dir="$(dirname "$dir")"
-    done
-}
+    function magic_from() {
+        local dir="$1"
+        [[ -z "$dir" ]] && return
 
-if [[ "$PWD" != "$MAGIC_LAST" ]]; then
+        while [[ "$dir" != "/" ]]; do
+            [[ -r "$dir/.spells" ]] && echo "$dir"
+            dir="$(dirname "$dir")"
+        done
+    }
 
-    uninstall="$(magic_from "$MAGIC_LAST")"
-    install="$(magic_from "$PWD" | tac)"
+    if [[ "$PWD" != "$MAGIC_LAST" ]]; then
 
-    if [[ "$uninstall" != "$install" ]]; then
+        uninstall="$(magic_from "$MAGIC_LAST")"
+        install="$(magic_from "$PWD" | tac)"
 
-        while read -r magic; do
-            if [[ ! -z "$magic" ]]; then
-                unset -f $(${SHELL} "$magic/.spells") 2>/dev/null
-            fi
-        done <<< "$uninstall"
+        if [[ "$uninstall" != "$install" ]]; then
 
-        while read -r magic; do
-            if [[ ! -z "$magic" ]]; then
-                source "$magic/.spells" > /dev/null
-            fi
-        done <<< "$install"
+            while read -r magic; do
+                if [[ ! -z "$magic" ]]; then
+                    unset -f $(${SHELL} "$magic/.spells") 2>/dev/null
+                fi
+            done <<< "$uninstall"
+
+            while read -r magic; do
+                if [[ ! -z "$magic" ]]; then
+                    source "$magic/.spells" > /dev/null
+                fi
+            done <<< "$install"
+        fi;
+
+        unset install uninstall
+        MAGIC_LAST="$PWD"
     fi;
 
-    unset install uninstall
-    MAGIC_LAST="$PWD"
-fi;
+    unset magic_from
+}
 
-unset magic_from
+if [ -n "$ZSH_VERSION" ]; then
+  autoload add-zsh-hook
+  add-zsh-hook precmd magic_load
+elif [ -n "$BASH_VERSION" ]; then
+  PROMPT_COMMAND="magic_load; $PROMPT_COMMAND"
+else
+  echo "Unknown shell not supported for magic"
+fi


### PR DESCRIPTION
In case you are interested, I updated magic to work with zsh plugin manager ([antidote](https://getantidote.github.io) in my case).

I used it for the last 6 months, with both bash (as usual) and with zsh as a plugin without any issues.
